### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # xADObject
 PowerShell DSC Resource for managing properties on any Active Directory Object.
 
-__Note:__ Right now there is no support for forcing the deletion of objects marked with the "Protect object from accidental deletion" option. This may or may not be added based on community feedback. So far the concensus from my coworkers is that the DSC Resource should not allow you to override that protection.
+__Note:__ Right now there is no support for forcing the deletion of objects marked with the "Protect object from accidental deletion" option. This may or may not be added based on community feedback. So far the consensus from my coworkers is that the DSC Resource should not allow you to override that protection.
 
 
 # Example


### PR DESCRIPTION
@platta, I've corrected a typographical error in the documentation of the [xADObject](https://github.com/platta/xADObject) project. Specifically, I've changed concensus to consensus. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
